### PR TITLE
feat: Implement Basic Admin Dashboard UI

### DIFF
--- a/admin_panel/src/components/dashboard/SummaryCard.tsx
+++ b/admin_panel/src/components/dashboard/SummaryCard.tsx
@@ -1,0 +1,57 @@
+// src/components/dashboard/SummaryCard.tsx
+import React from 'react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  // CardDescription, // Optional
+  // CardFooter, // Optional
+} from "@/components/ui/card"; // Shadcn UI Card components
+
+interface SummaryCardProps {
+  title: string;
+  value: string | number;
+  description?: string; // Optional description or subtext
+  // icon?: React.ReactNode; // Optional icon
+  isLoading?: boolean;
+}
+
+const SummaryCard: React.FC<SummaryCardProps> = ({
+  title,
+  value,
+  description,
+  // icon,
+  isLoading = false
+}) => {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">
+          {title}
+        </CardTitle>
+        {/* {icon && <div className="text-muted-foreground">{icon}</div>} */}
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <>
+            <div className="text-2xl font-bold animate-pulse bg-muted h-8 w-1/2 rounded-md"></div>
+            {description && <p className="text-xs text-muted-foreground animate-pulse bg-muted h-4 w-3/4 mt-1 rounded-md"></p>}
+          </>
+        ) : (
+          <>
+            <div className="text-2xl font-bold">{value}</div>
+            {description && (
+              <p className="text-xs text-muted-foreground">
+                {description}
+              </p>
+            )}
+          </>
+        )}
+      </CardContent>
+      {/* Optional CardFooter can be added here if needed */}
+    </Card>
+  );
+};
+
+export default SummaryCard;

--- a/admin_panel/src/components/ui/card.tsx
+++ b/admin_panel/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/admin_panel/src/pages/Dashboard/DashboardPage.tsx
+++ b/admin_panel/src/pages/Dashboard/DashboardPage.tsx
@@ -1,12 +1,125 @@
 // src/pages/Dashboard/DashboardPage.tsx
-import React from 'react';
+import React, { useEffect, useState, useCallback } from 'react'; // Added useEffect, useState, useCallback
+import { useAuth } from '@/contexts/AuthContext';
+import SummaryCard from '@/components/dashboard/SummaryCard'; // Assuming SummaryCard is ready
+import { get as apiGet } from '@/services/api'; // For API calls
+import { Link } from 'react-router-dom'; // Import Link
+// import { Button } from '@/components/ui/button'; // Not strictly needed if Link is styled directly
+
+// Define a generic type for paginated API responses that include a 'total'
+interface PaginatedResponseWithTotal {
+  total: number;
+  // Other pagination fields like data, current_page etc., are not strictly needed here
+  // but might be present in the actual response.
+}
 
 const DashboardPage: React.FC = () => {
+  const { user } = useAuth();
+
+  const [userCount, setUserCount] = useState<number | string>('--');
+  const [groupCount, setGroupCount] = useState<number | string>('--');
+  const [planCount, setPlanCount] = useState<number | string>('--');
+  const [nodeCount, setNodeCount] = useState<number | string>('--');
+
+  const [isLoadingStats, setIsLoadingStats] = useState(true);
+  const [errorStats, setErrorStats] = useState<string | null>(null);
+
+  const fetchDashboardStats = useCallback(async () => {
+    setIsLoadingStats(true);
+    setErrorStats(null);
+    try {
+      // Fetch all stats concurrently
+      const [
+        usersResponse,
+        groupsResponse,
+        plansResponse,
+        nodesResponse
+      ] = await Promise.all([
+        apiGet<PaginatedResponseWithTotal>('/admin/users?per_page=1'), // Fetch only 1 item to get total efficiently
+        apiGet<PaginatedResponseWithTotal>('/admin/user-groups?per_page=1'),
+        apiGet<PaginatedResponseWithTotal>('/admin/plans?per_page=1'),
+        apiGet<PaginatedResponseWithTotal>('/admin/nodes?per_page=1'),
+      ]);
+
+      setUserCount(usersResponse.data.total);
+      setGroupCount(groupsResponse.data.total);
+      setPlanCount(plansResponse.data.total);
+      setNodeCount(nodesResponse.data.total);
+
+    } catch (err: any) {
+      console.error("Failed to fetch dashboard stats:", err);
+      setErrorStats(err.message || 'Failed to load summary data.');
+      // Set counts to error state or keep as '--'
+      setUserCount('Error');
+      setGroupCount('Error');
+      setPlanCount('Error');
+      setNodeCount('Error');
+    } finally {
+      setIsLoadingStats(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchDashboardStats();
+  }, [fetchDashboardStats]);
+
   return (
-    <div>
-      <h2>Dashboard</h2>
-      <p>Welcome to the admin dashboard!</p>
+    <div className="container mx-auto py-10">
+      <div className="mb-8">
+        <h1 className="text-4xl font-bold mb-2">Admin Dashboard</h1>
+        {user ? (
+          <p className="text-xl text-muted-foreground">
+            Welcome back, {user.email}!
+          </p>
+        ) : (
+          <p className="text-xl text-muted-foreground">
+            Welcome to the Admin Dashboard.
+          </p>
+        )}
+      </div>
+
+      <section aria-labelledby="summary-stats-heading">
+        <h2 id="summary-stats-heading" className="text-2xl font-semibold mb-4 sr-only">
+          Summary Statistics
+        </h2>
+        {errorStats && <p className="text-red-500 mb-4">Error loading statistics: {errorStats}</p>}
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4 mb-8">
+          <SummaryCard title="Total Users" value={userCount} isLoading={isLoadingStats} />
+          <SummaryCard title="Total User Groups" value={groupCount} isLoading={isLoadingStats} />
+          <SummaryCard title="Total Plans" value={planCount} isLoading={isLoadingStats} />
+          <SummaryCard title="Total Nodes" value={nodeCount} isLoading={isLoadingStats} />
+        </div>
+      </section>
+
+      {/* ... (Quick Actions section remains the same) ... */}
+      <section aria-labelledby="quick-actions-heading">
+        <h2 id="quick-actions-heading" className="text-2xl font-semibold mb-4">
+          Quick Actions
+        </h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4"> {/* Adjusted to lg:grid-cols-4 for 4 items */}
+          <Link to="/users" className="block p-6 border rounded-lg shadow-sm hover:shadow-md transition-shadow bg-card text-card-foreground hover:bg-accent">
+            <h3 className="text-lg font-medium mb-1">Manage Users</h3>
+            <p className="text-sm text-muted-foreground">View, add, edit, or delete users.</p>
+          </Link>
+
+          <Link to="/nodes" className="block p-6 border rounded-lg shadow-sm hover:shadow-md transition-shadow bg-card text-card-foreground hover:bg-accent">
+            <h3 className="text-lg font-medium mb-1">Manage Nodes</h3>
+            <p className="text-sm text-muted-foreground">Add new nodes or manage existing ones.</p>
+          </Link>
+
+          <Link to="/plans" className="block p-6 border rounded-lg shadow-sm hover:shadow-md transition-shadow bg-card text-card-foreground hover:bg-accent">
+            <h3 className="text-lg font-medium mb-1">Manage Plans</h3>
+            <p className="text-sm text-muted-foreground">Create and configure subscription plans.</p>
+          </Link>
+
+          <Link to="/user-groups" className="block p-6 border rounded-lg shadow-sm hover:shadow-md transition-shadow bg-card text-card-foreground hover:bg-accent">
+            <h3 className="text-lg font-medium mb-1">Manage User Groups</h3>
+            <p className="text-sm text-muted-foreground">Organize users into groups.</p>
+          </Link>
+        </div>
+      </section>
     </div>
   );
 };
+
 export default DashboardPage;


### PR DESCRIPTION
This commit completes the implementation of a basic Admin Dashboard for Phase 2 of the Admin Panel development.

Key changes in the `admin_panel/` directory include:

1.  **Dashboard Page Structure (`DashboardPage.tsx`):**
    *   Enhanced the existing placeholder page with a structured layout.
    *   Includes a personalized welcome message for the logged-in admin.
    *   Defines sections for "Summary Statistics" and "Quick Actions."

2.  **Summary Card Component (`SummaryCard.tsx`):**
    *   Added the Shadcn UI `Card` component.
    *   Created a reusable `SummaryCard` to display a title, a value,
        and an optional description, with a built-in loading state
        (skeleton placeholder).

3.  **Data Fetching for Summary Cards (`DashboardPage.tsx`):**
    *   Implemented logic to fetch total counts for Users, User Groups,
        Plans, and Nodes from their respective backend API list endpoints
        (using `per_page=1` for efficiency).
    *   Handles loading and error states for these API calls.

4.  **Display Summary Cards (`DashboardPage.tsx`):**
    *   Uses the `SummaryCard` component to display the fetched counts
        on the dashboard.

5.  **Quick Links/Actions Section (`DashboardPage.tsx`):**
    *   Implemented functional links (styled as clickable cards) to the
        management pages for Users, Nodes, Plans, and User Groups.

6.  **Default Route Verification:**
    *   Confirmed that the Dashboard page (`/`) is the default protected
        route after login.

This provides a basic overview and navigation hub for the admin panel. The main CRUD UIs for Users, User Groups, Plans, and Nodes were completed in previous commits for this feature branch.